### PR TITLE
Add the 'Begin' Quest to each .md file

### DIFF
--- a/Quest_Guide/quests/classes_quest.md
+++ b/Quest_Guide/quests/classes_quest.md
@@ -7,6 +7,7 @@ layout: default
 
 ### Prerequisites
 
+- Begin Quest
 - Welcome Quest
 - Power of Puppet Quest
 - Resources Quest

--- a/Quest_Guide/quests/conditions_quest.md
+++ b/Quest_Guide/quests/conditions_quest.md
@@ -7,6 +7,7 @@ layout: default
 
 ### Prerequisites
 
+- Begin Quest
 - Welcome Quest
 - Power of Puppet Quest
 - Resources Quest

--- a/Quest_Guide/quests/manifest_quest.md
+++ b/Quest_Guide/quests/manifest_quest.md
@@ -7,6 +7,7 @@ layout: default
 
 ### Prerequisites
 
+- Begin Quest
 - Welcome Quest
 - Power of Puppet Quest
 - Resources Quest

--- a/Quest_Guide/quests/modules_quest.md
+++ b/Quest_Guide/quests/modules_quest.md
@@ -7,6 +7,7 @@ layout: default
 
 ### Prerequisites
 
+- Begin Quest
 - Welcome Quest
 - Power of Puppet Quest
 - Resources Quest

--- a/Quest_Guide/quests/power_of_puppet.md
+++ b/Quest_Guide/quests/power_of_puppet.md
@@ -7,6 +7,7 @@ layout: default
 
 ### Prerequisites
 
+- Begin Quest
 - Welcome Quest
 
 ## Quest Objectives

--- a/Quest_Guide/quests/puppet_module_tool_quest.md
+++ b/Quest_Guide/quests/puppet_module_tool_quest.md
@@ -7,6 +7,7 @@ layout: default
 
 ### Prerequisites
 
+- Begin Quest
 - Welcome Quest
 - Power of Puppet Quest
 - Resources Quest

--- a/Quest_Guide/quests/resource_ordering.md
+++ b/Quest_Guide/quests/resource_ordering.md
@@ -7,6 +7,7 @@ layout: default
 
 ### Prerequisites
 
+- Begin Quest
 - Welcome Quest
 - Power of Puppet Quest
 - Resources Quest

--- a/Quest_Guide/quests/resources.md
+++ b/Quest_Guide/quests/resources.md
@@ -7,6 +7,7 @@ layout: default
 
 ### Prerequisites
 
+- Begin Quest
 - Welcome Quest
 - Power of Puppet Quest
 

--- a/Quest_Guide/quests/variables.md
+++ b/Quest_Guide/quests/variables.md
@@ -7,6 +7,7 @@ layout: default
 
 ### Prerequisites
 
+- Begin Quest
 - Welcome Quest
 - Power of Puppet Quest
 - Resources Quest


### PR DESCRIPTION
On my learning VM, I have a quest called "Begin" that doesn't get
mentioned in any of the other quests.  This pull request brings them
inline with what the users environment should actually look like.

As an example (from my learning VM):

 # quest -c
  The following quests have been completed! :
  Begin
  Welcome
  Power
  Resources
  Manifest
  Variables