### PR TITLE
typo in variables quest task 2

### DIFF
--- a/Quest_Guide/quests/variables_and_parameters.md
+++ b/Quest_Guide/quests/variables_and_parameters.md
@@ -150,7 +150,7 @@ class web {
     content => "<em>${english}</em>",
   }
   
-  file { "${doc_root}/bonjour.html"}
+  file { "${doc_root}/bonjour.html":
     ensure => 'present',
     content => "<em>${french}</em>",
   }


### PR DESCRIPTION
small typo that prevents successful execution, removes an extra curly brace