### PR TITLE
Lengthen tmux quest status display

### DIFF
--- a/quest_tool/.tmux.conf
+++ b/quest_tool/.tmux.conf
@@ -18,7 +18,7 @@ setw -g automatic-rename on
 
 # status right options
 set-option -g status-right 'Quest: #[fg=cyan]#(cat /tmp/quest--listbrief.out) #[fg=white]- Progress: #[fg=yellow]#(cat /tmp/quest--progressbrief.out) #[fg=white]Tasks. '
-set-option -g status-right-length 60
+set-option -g status-right-length 70
 
 # refresh often
 set-option  -g status-interval 2


### PR DESCRIPTION
Changed the tmux quest status display to 70 characters. It can now fit all quest names properly.