### PR TITLE
Updating resource ordering spec to prevent Task 4 from being completed by installing sshd

### DIFF
--- a/quest_tool/.testing/spec/localhost/resource_ordering_spec.rb
+++ b/quest_tool/.testing/spec/localhost/resource_ordering_spec.rb
@@ -24,8 +24,8 @@ end
 
 describe "Task 4:" do
   it "Disable GSSAPIAuthentication in the module's sshd_config file" do
-    file("#{MODULE_PATH}sshd/files/sshd_config").should contain "^GSSAPIAuthentication no"
-    file("#{MODULE_PATH}sshd/files/sshd_config").should_not contain "^GSSAPIAuthentication yes"
+    file("#{MODULE_PATH}sshd/files/sshd_config").content.should match /^GSSAPIAuthentication no/
+    file("#{MODULE_PATH}sshd/files/sshd_config").content.should_not match /^GSSAPIAuthentication yes/
   end
 end
 

--- a/quest_tool/.testing/spec/localhost/resource_ordering_spec.rb
+++ b/quest_tool/.testing/spec/localhost/resource_ordering_spec.rb
@@ -24,7 +24,8 @@ end
 
 describe "Task 4:" do
   it "Disable GSSAPIAuthentication in the module's sshd_config file" do
-    file("#{MODULE_PATH}sshd/files/sshd_config").should contain "GSSAPIAuthentication no"
+    file("#{MODULE_PATH}sshd/files/sshd_config").should contain "^GSSAPIAuthentication no"
+    file("#{MODULE_PATH}sshd/files/sshd_config").should_not contain "^GSSAPIAuthentication yes"
   end
 end
 


### PR DESCRIPTION
When installing sshd, these two lines are in the config showing GSSAPI options:
   #GSSAPIAuthentication no
   GSSAPIAuthenication yes

The current spec will always be successful because the first line matches even though it's just a comment