### PR TITLE
update rake puppet ruby path

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -78,7 +78,7 @@ task :test_all do
 end
 
 task :helper do
-  `/opt/puppet/bin/ruby /usr/src/courseware-lvm/update_helper.rb`
+  `/opt/puppetlabs/puppet/bin/ruby /usr/src/courseware-lvm/update_helper.rb`
 end
 
 # Helper Functions


### PR DESCRIPTION
The initial build process invokes the Rakefile, so we need to update this to get a working 2015.2 VM to use for testing.