### PR TITLE
remove spec_helper from task specs

### DIFF
--- a/quests/conditional_statements/conditional_statements_spec.rb
+++ b/quests/conditional_statements/conditional_statements_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe "Task 1:" do
   it 'Create the directory structure for your accounts module' do
     file("#{MODULE_PATH}accounts").should be_directory

--- a/quests/manifests_and_classes/manifests_and_classes_spec.rb
+++ b/quests/manifests_and_classes/manifests_and_classes_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe "Task 1:" do
   it 'Define the cowsayings::cowsay class' do
     file("#{MODULE_PATH}cowsayings/manifests/cowsay.pp").should be_file

--- a/quests/modules/modules_spec.rb
+++ b/quests/modules/modules_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe "Task 1:" do 
   it 'Use puppet master --configprint find the modulepath' do
     file('/root/.bash_history').should contain "puppet master --configprint modulepath"

--- a/quests/mysql/mysql_spec.rb
+++ b/quests/mysql/mysql_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe "Task 1:" do
   it 'Install the puppetlabs-mysql module' do
     file("#{MODULE_PATH}mysql").should be_directory

--- a/quests/ntp/ntp_spec.rb
+++ b/quests/ntp/ntp_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe "Task 1:" do
   it 'Install the puppetlabs-ntp module' do
     file("#{MODULE_PATH}ntp").should be_directory

--- a/quests/power_of_puppet/power_of_puppet_spec.rb
+++ b/quests/power_of_puppet/power_of_puppet_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Task 1:' do
   it 'Use the puppet module tool to search for graphite' do
     file('/root/.bash_history').should contain "puppet module search graphite"

--- a/quests/resource_ordering/resource_ordering_spec.rb
+++ b/quests/resource_ordering/resource_ordering_spec.rb
@@ -1,6 +1,3 @@
-require 'spec_helper'
-
-
 describe "Task 1:" do
   it 'Create the sshd module directory with manifests, tests, and files subdirectories' do
     file("#{MODULE_PATH}sshd").should be_directory

--- a/quests/resources/resources_spec.rb
+++ b/quests/resources/resources_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe "Task 1:" do
   it 'Inspect the root user resource' do
     file('/root/.bash_history').should contain 'puppet resource user root'

--- a/quests/variables_and_parameters/variables_and_parameters_spec.rb
+++ b/quests/variables_and_parameters/variables_and_parameters_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe "Task 1:" do
   it 'Create the directory structure for your web module' do
     file("#{MODULE_PATH}web").should be_directory


### PR DESCRIPTION
We're using rspec internally and configuring it in the quest tool, so no spec_helper is necessary.