### PR TITLE
Add missing parameter for consistency

### DIFF
--- a/Quest_Guide/quests/defined_resource_types.md
+++ b/Quest_Guide/quests/defined_resource_types.md
@@ -415,6 +415,7 @@ define web_user::user (
   file { "${public_html}/index.html":
     ensure  => file,
     owner   => $title,
+    group   => $title,
     replace => false,
     content => $content,
     mode    => '0644',

--- a/Quest_Guide/quests/defined_resource_types.md
+++ b/Quest_Guide/quests/defined_resource_types.md
@@ -409,6 +409,7 @@ define web_user::user (
   file { [$home_dir, $public_html]:
     ensure => directory,
     owner  => $title,
+    group  => $title,
     mode    => '0755',
   }
   file { "${public_html}/index.html":


### PR DESCRIPTION
Hi there,

While going through the Defined Resource Types quest, I noticed that while in Task 5 we define both "owner" and "group" in the "file { [$home_dir, $public_html]:" section, in Task 7 we only define "owner".

This change simply adds "group" to Task 7 in two places to make it consistent.