### PR TITLE
specify version of dwerder-graphite to install

### DIFF
--- a/Quest_Guide/quests/power_of_puppet.md
+++ b/Quest_Guide/quests/power_of_puppet.md
@@ -80,7 +80,7 @@ Now that you know what module you want, you'll need to install it to the Puppet
 master to make it available for your infrastructure. The `puppet module` tool makes
 this installation easy. Go ahead and run:
 
-    puppet module install dwerder-graphite
+    puppet module install dwerder-graphite --version 5.16.1
     
 {% aside Offline? %}
 If you don't have internet access, run the following terminal commands to use


### PR DESCRIPTION
The latest version of dwerder-graphite (v6.0.1) was released as of 2016-04-01, and it causes the tasks in `power_of_puppet.md` to fail. I couldn't figure out what combination of parameters to use that would make it succeed, so instead I've modified the task to install v5.16.1 of this module. I think there's enough that's changed in Daniel's module that there might be other parts of this quest that would be broken as a result of using the latest version.